### PR TITLE
Suppression Swarex - Responsable carte des membres

### DIFF
--- a/community/roles.md
+++ b/community/roles.md
@@ -221,9 +221,9 @@
           <li>Créer les liens pour les nouveaux membres qui demandent</li>
         </ul>
       </td>
-      <td style="text-align: center;">1 (1 max)</td>
-      <td style="text-align: center;">Swarex</td>
-      <td style="text-align: center;">Swarex</td>
+      <td style="text-align: center;">0 (1 max)</td>
+      <td style="text-align: center;">?</td>
+      <td style="text-align: center;">?</td>
       <td style="text-align: center;">Volontaire</td>
     </tr>
     <td style="text-align: center;">X (Twitter)</td>


### PR DESCRIPTION
Swarex ne faisant plus parti de la communauté, il est normal qu'il soit retiré de la liste. Une personne devra aussi être trouvée pour le remplacer, mais ca, c'est une autre histoire