### PR TITLE
Election nouveaux médiateurs

### DIFF
--- a/community/roles.md
+++ b/community/roles.md
@@ -357,7 +357,7 @@
       </td>
       <td style="text-align: center;">7 (7 voulu)</td>
       <td style="text-align: center;">Aucun</td>
-      <td style="text-align: center;">Snake, Backdraft, Thomas, Taykay, Odin, Clem0233 , Mac</td>
+      <td style="text-align: center;">Backdraft, _dylan51, Pierre, Valdum, Remigdv, Odin, Emmanueltzt</td>
       <td style="text-align: center;">Vote des membres de la commu <br><br><strong> Il ne faut jamais avoir eu de sanctions</td>
     </tr>
     <td style="text-align: center;">Validation Mappings</td>


### PR DESCRIPTION
Suite à l'élection, nouveaux médiateurs à inscrire pour les 4 prochains mois
https://sadoj-rp.fr/votes-reunion-du-09-06-2024/