### PR TITLE
Ajout CharlieS groupe justice

### DIFF
--- a/community/roles.md
+++ b/community/roles.md
@@ -255,9 +255,9 @@
           <li>Traitement des situations juridiques particulières</li>
         </ul>
       </td>
-      <td style="text-align: center;">6 (7 voulu)</td>
+      <td style="text-align: center;">7 (7 voulu)</td>
       <td style="text-align: center;">Guillaume</td>
-      <td style="text-align: center;">Guillaume, Kuro, Esteban, Dylan51, UrtomT, Mentalomane</td>
+      <td style="text-align: center;">Guillaume, Kuro, Esteban, Dylan51, UrtomT, Mentalomane, CharlieS</td>
       <td style="text-align: center;">Vote des membres de la commu <br><br><strong>3 mois d'ancienneté dans la communauté</td>
     </tr>
     <td style="text-align: center;">Groupe Dark (Life)</td>


### PR DESCRIPTION
Suite à un vote en décembre dernier, CharlieS avait été élu mais on a oublié de le rajouter